### PR TITLE
Add Node 22 and ignore .md files from triggering the workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+      paths-ignore:
+      - '**/*.md'
+  pull_request:
+      paths-ignore:
+      - '**/*.md'
+
 jobs:
   test:
     name: Node.js ${{ matrix.node-version }}
@@ -10,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
+          - 22
           - 20
           - 18
     steps:


### PR DESCRIPTION
- Add Node.js 22
- Ignore `.md` files from triggering the workflow, to reduce unnecessary builds or tests when documentation files are updated